### PR TITLE
Allow Cif Records to be written.

### DIFF
--- a/CifParser/Records/Association.cs
+++ b/CifParser/Records/Association.cs
@@ -98,6 +98,7 @@ namespace CifParser.Records
         [FieldFixedLength(1)]
         [FieldTrim(TrimMode.Right)]
         [FieldNullValue(1)]
+        [FieldConverter(typeof(SequenceConverter))]
         public int MainSequence { get; set; } = -1;
 
         /// <summary>
@@ -108,6 +109,7 @@ namespace CifParser.Records
         [FieldFixedLength(1)]
         [FieldTrim(TrimMode.Right)]
         [FieldNullValue(1)]
+        [FieldConverter(typeof(SequenceConverter))]
         public int AssociationSequence { get; set; } = -1;
         /// <summary>
         /// Diagram Type - always T

--- a/CifParser/Records/IntermediateLocation.cs
+++ b/CifParser/Records/IntermediateLocation.cs
@@ -32,6 +32,7 @@ namespace CifParser.Records
         /// This is to handle where a location appears multiple times in a schedule</remarks>
         [FieldFixedLength(1)]
         [FieldTrim(TrimMode.Right)]
+        [FieldConverter(typeof(SequenceConverter))]
         [FieldNullValue(1)]
         public int Sequence { get; set; } = -1;
         /// <summary>

--- a/CifParser/Records/OriginLocation.cs
+++ b/CifParser/Records/OriginLocation.cs
@@ -32,6 +32,7 @@ namespace CifParser.Records
         /// This is to handle where a location appears multiple times in a schedule</remarks>
         [FieldFixedLength(1)]
         [FieldTrim(TrimMode.Right)]
+        [FieldConverter(typeof(SequenceConverter))]
         [FieldNullValue(1)]
         public int Sequence { get; set; } = -1;
         /// <summary>

--- a/CifParser/Records/ReservationIndicatorConverter.cs
+++ b/CifParser/Records/ReservationIndicatorConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using FileHelpers;
+
+namespace CifParser.Records
+{
+    public class ReservationIndicatorConverter : ConverterBase
+    {
+        public override object StringToField(string @from)
+        {
+            return Enum.Parse(typeof(ReservationIndicator), @from);
+        }
+
+        public override string FieldToString(object @from)
+        {
+            if (@from is ReservationIndicator reservationIndicator)
+            {
+                switch (reservationIndicator)
+                {
+                    case ReservationIndicator.None:
+                        return " ";
+                    case ReservationIndicator.A:
+                        return "A";
+                    case ReservationIndicator.R:
+                        return "R";
+                    case ReservationIndicator.S:
+                        return "S";
+                    case ReservationIndicator.E:
+                        return "E";
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+
+            throw new InvalidOperationException();
+        }
+    }
+}

--- a/CifParser/Records/ScheduleActionConverter.cs
+++ b/CifParser/Records/ScheduleActionConverter.cs
@@ -19,5 +19,27 @@ namespace CifParser.Records
                     throw new InvalidOperationException($"Invalid record type {source}");
             }
         }
+
+        public override string FieldToString(object @from)
+        {
+            if (@from is RecordAction recordAction)
+            {
+                switch (recordAction)
+                {
+                    case RecordAction.NotSet:
+                        throw new InvalidOperationException($"Invalid record type {recordAction}");
+                    case RecordAction.Create:
+                        return "N";
+                    case RecordAction.Update:
+                        return "R";
+                    case RecordAction.Delete:
+                        return "D";
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+            throw new InvalidOperationException($"Invalid record type {@from.GetType()}");
+
+        }
     }
 }

--- a/CifParser/Records/ScheduleChange.cs
+++ b/CifParser/Records/ScheduleChange.cs
@@ -31,6 +31,7 @@ namespace CifParser.Records
         /// This is to handle where a location appears multiple times in a schedule</remarks>
         [FieldFixedLength(1)]
         [FieldTrim(TrimMode.Right)]
+        [FieldConverter(typeof(SequenceConverter))]
         [FieldNullValue(1)]
         public int Sequence { get; set; } = -1;
         /// <summary>
@@ -120,6 +121,7 @@ namespace CifParser.Records
         [FieldFixedLength(1)]
         [FieldTrim(TrimMode.Right)]
         [FieldNullValue(ServiceClass.B)]
+        [FieldConverter(typeof(ServiceClassConverter))]
         public ServiceClass SeatClass { get; set; } = ServiceClass.None;
 
         /// <summary>
@@ -133,6 +135,7 @@ namespace CifParser.Records
         [FieldFixedLength(1)]
         [FieldTrim(TrimMode.Right)]
         [FieldNullValue(ServiceClass.None)]
+        [FieldConverter(typeof(ServiceClassConverter))]
         public ServiceClass SleeperClass { get; set; } = ServiceClass.None;
 
         /// <summary>
@@ -142,6 +145,7 @@ namespace CifParser.Records
         /// Values: ARSE </remarks>
         [FieldFixedLength(1)]
         [FieldNullValue(ReservationIndicator.None)]
+        [FieldConverter(typeof(ReservationIndicatorConverter))]
         public ReservationIndicator ReservationIndicator { get; set; } = ReservationIndicator.None;
         /// <summary>
         /// Connect Indicator - NOT USED

--- a/CifParser/Records/ScheduleDetails.cs
+++ b/CifParser/Records/ScheduleDetails.cs
@@ -195,6 +195,7 @@ namespace CifParser.Records
         [FieldFixedLength(1)]
         [FieldTrim(TrimMode.Right)]
         [FieldNullValue(ServiceClass.B)]
+        [FieldConverter(typeof(ServiceClassConverter))]
         public ServiceClass SeatClass { get; set; } = ServiceClass.None;
 
         /// <summary>
@@ -208,6 +209,7 @@ namespace CifParser.Records
         [FieldFixedLength(1)]
         [FieldTrim(TrimMode.Right)]
         [FieldNullValue(ServiceClass.None)]
+        [FieldConverter(typeof(ServiceClassConverter))]
         public ServiceClass SleeperClass { get; set; } = ServiceClass.None;
         /// <summary>
         /// Reservation indicator
@@ -216,6 +218,7 @@ namespace CifParser.Records
         /// Values: ARSE </remarks>
         [FieldFixedLength(1)]
         [FieldNullValue(ReservationIndicator.None)]
+        [FieldConverter(typeof(ReservationIndicatorConverter))]
         public ReservationIndicator ReservationIndicator { get; set; } = ReservationIndicator.None;
         /// <summary>
         /// Connect Indicator - NOT USED

--- a/CifParser/Records/SequenceConverter.cs
+++ b/CifParser/Records/SequenceConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using FileHelpers;
+
+namespace CifParser.Records
+{
+    public class SequenceConverter : ConverterBase
+    {
+        public override object StringToField(string @from)
+        {
+            if (string.IsNullOrEmpty(@from))
+                return 1;
+
+            return int.Parse(@from);
+        }
+
+        public override string FieldToString(object @from)
+        {
+            if (@from is int sequence)
+            {
+                return sequence == 1 ? " " : sequence.ToString();
+            }
+
+            throw new InvalidOperationException($"Invalid record type {@from.GetType()}");
+        }
+        
+    }
+}

--- a/CifParser/Records/ServiceClassConverter.cs
+++ b/CifParser/Records/ServiceClassConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using FileHelpers;
+
+namespace CifParser.Records
+{
+    public class ServiceClassConverter : ConverterBase
+    {
+        public override object StringToField(string @from)
+        {
+            return Enum.Parse(typeof(ServiceClass), @from);
+        }
+
+        public override string FieldToString(object @from)
+        {
+            if (@from is ServiceClass sc)
+            {
+                switch (sc)
+                {
+                    case ServiceClass.None:
+                        return " ";
+                    case ServiceClass.B:
+                        return "B";
+                    case ServiceClass.S:
+                        return "S";
+                    case ServiceClass.F:
+                        return "F";
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+
+            throw new InvalidOperationException();
+        }
+    }
+}

--- a/CifParser/Records/TerminalLocation.cs
+++ b/CifParser/Records/TerminalLocation.cs
@@ -31,6 +31,7 @@ namespace CifParser.Records
         /// This is to handle where a location appears multiple times in a schedule</remarks>
         [FieldFixedLength(1)]
         [FieldTrim(TrimMode.Right)]
+        [FieldConverter(typeof(SequenceConverter))]
         [FieldNullValue(1)]
         public int Sequence { get; set; } = -1;
         /// <summary>

--- a/CifParser/Records/TimeConverter.cs
+++ b/CifParser/Records/TimeConverter.cs
@@ -23,6 +23,26 @@ namespace CifParser.Records
             return ParseTime(source);
         }
 
+        public override string FieldToString(object @from)
+        {
+            
+            if (@from is TimeSpan timeSpan)
+            {
+                
+                var time = timeSpan.ToString("hhmm", Culture);
+                if (timeSpan.Seconds == 30)
+                    time += "H";
+                return time;
+            }
+
+            if (@from == null)
+            {
+                return NullValue;
+            }
+
+            throw new InvalidOperationException($"Invalid record type {@from.GetType()}");
+        }
+
         protected virtual TimeSpan ParseTime(string source)
         {
             return TimeSpan.ParseExact(source, "hhmm", Culture);

--- a/CifParser/Records/TiplocRecordConverter.cs
+++ b/CifParser/Records/TiplocRecordConverter.cs
@@ -19,5 +19,27 @@ namespace CifParser.Records
                     throw new InvalidOperationException($"Invalid record type {source}");
             }
         }
+
+        public override string FieldToString(object @from)
+        {
+            if (@from is RecordAction recordAction)
+            {
+                switch (recordAction)
+                {
+                    case RecordAction.NotSet:
+                        throw new InvalidOperationException($"Invalid record type {recordAction}");
+                    case RecordAction.Create:
+                        return "TI";
+                    case RecordAction.Update:
+                        return "TA";
+                    case RecordAction.Delete:
+                        return "TD";
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+
+            throw new InvalidOperationException($"{@from.GetType()} is unsupported");
+        }
     }
 }


### PR DESCRIPTION
This is a first pass at allowing cif records to be written back using FileHelpers.

This was a quick go that appears to work on my side, however I am not very familiar with the FileHelpers library or all the intricacies of the cif format.

This PR adds converters for properties that have FieldNullValues:

- Sequence
- Main Sequence
- Associated Sequence
- Seat Class
- Sleeper Class
- Reservation Indecator

It also adds FieldToString methods for each of the existing and new converters to ensure written files match the incoming cif format.